### PR TITLE
add transaddition and transdeletion features

### DIFF
--- a/src/Collective.jl
+++ b/src/Collective.jl
@@ -14,9 +14,6 @@ export Corpus,
        best_clusters,
        common_features
 
-include("feature_expressions.jl")
-include("features.jl")
-
 function wordlist(data::IO)
     words = lowercase.(strip.(vec(readdlm(data, ',', String))))
     for i in 1:length(words)
@@ -24,6 +21,11 @@ function wordlist(data::IO)
     end
     words
 end
+
+include("bitstally.jl")
+import .BitsTallies: BitsTally, isanagram, istransaddition
+include("feature_expressions.jl")
+include("features.jl")
 
 type Corpus{F}
     features::FeatureSet{F}

--- a/src/bitstally.jl
+++ b/src/bitstally.jl
@@ -1,6 +1,6 @@
 module BitsTallies
 
-import Base: getindex, +
+import Base: getindex, +, -
 
 const BITS = 5
 const mask = UInt8(2 ^ BITS - 1)
@@ -30,6 +30,8 @@ end
 Add a single count for char c to the tally t. 
 """
 +(t::BitsTally, c::Char) = BitsTally(t.data + charmasks[convert(Int, c - 'a' + 1)])
+
+-(t::BitsTally, c::Char) = BitsTally(t.data - charmasks[convert(Int, c - 'a' + 1)])
 
 function BitsTally(s::String)
     t = BitsTally()

--- a/src/bitstally.jl
+++ b/src/bitstally.jl
@@ -7,12 +7,28 @@ const mask = UInt8(2 ^ BITS - 1)
 const offsets = [BITS * i for i in 0:25]
 const charmasks = [UInt128(1) << x for x in offsets]
 
+"""
+The BitsTally uses a single unsigned integer to store counts 
+for every letter in 'a':'z'. This lets us compute those tallies
+without allocating an array, and compare them using simple 
+integer equality. 
+
+The way we do this is to divide up the internal 128-bit integer into 26
+blocks. Each block is 5 bits long, except the final block which is only 3 bits
+long. We can use each of those blocks to store a 5-bit count of a given
+letter. We store the counts for the letter 'a' in the low-order bits, which
+leaves the awkward 3-bit block for 'z'. So this will overflow if a word
+contains more than 7 'z's. or more than 31 of any other letter.
+"""
 immutable BitsTally
     data::UInt128
 
     BitsTally(data=0) = new(data)
 end
 
+"""
+Add a single count for char c to the tally t. 
+"""
 +(t::BitsTally, c::Char) = BitsTally(t.data + charmasks[convert(Int, c - 'a' + 1)])
 
 function BitsTally(s::String)
@@ -23,10 +39,18 @@ function BitsTally(s::String)
     t
 end
 
+"""
+Strip the appropriate bits out of the storage UInt128 to return the count of
+the given letter as a UInt8. 
+"""
 getindex(t::BitsTally, c::Char) = mod((t.data >> offsets[convert(Int, c - 'a' + 1)]) & mask, UInt8)
 
 isanagram(t1::BitsTally, t2::BitsTally) = t1.data == t2.data
 
+"""
+Returns true iff t1 is a transaddition of t2. That is, the letters of t2
+can be rearranged along with one extra letter to make the letters of t1. 
+"""
 function istransaddition(t1::BitsTally, t2::BitsTally)
     d = t1.data - t2.data
     for m in charmasks

--- a/src/bitstally.jl
+++ b/src/bitstally.jl
@@ -1,0 +1,40 @@
+module BitsTallies
+
+import Base: getindex, +
+
+const BITS = 5
+const mask = UInt8(2 ^ BITS - 1)
+const offsets = [BITS * i for i in 0:25]
+const charmasks = [UInt128(1) << x for x in offsets]
+
+immutable BitsTally
+    data::UInt128
+
+    BitsTally(data=0) = new(data)
+end
+
++(t::BitsTally, c::Char) = BitsTally(t.data + charmasks[convert(Int, c - 'a' + 1)])
+
+function BitsTally(s::String)
+    t = BitsTally()
+    for c in s
+        t += c
+    end
+    t
+end
+
+getindex(t::BitsTally, c::Char) = mod((t.data >> offsets[convert(Int, c - 'a' + 1)]) & mask, UInt8)
+
+isanagram(t1::BitsTally, t2::BitsTally) = t1.data == t2.data
+
+function istransaddition(t1::BitsTally, t2::BitsTally)
+    d = t1.data - t2.data
+    for m in charmasks
+        if d == m
+            return true
+        end
+    end
+    false
+end
+
+end

--- a/src/features.jl
+++ b/src/features.jl
@@ -44,6 +44,8 @@ function allfeatures()
         @feature(ismatch(ENTIRELY_STATES_REGEX, word), "can be completely broken down into US state abbreviations")
         @feature((num_state_abbreviations(word) == j for j in 1:5), "contains $j US state abbreviations")
         @feature(in(word, MA_BELL_EXCHANGES_SET), "is a Ma Bell recommended telephone exchange name")
+        @feature(has_transaddition(BitsTally(word)), "has a single-letter transaddition")
+        @feature(has_transdeletion(BitsTally(word)), "has a single-letter transdeletion")
         ]
 end
 
@@ -95,6 +97,27 @@ const ELEMENT_DATA = readdlm(joinpath(Pkg.dir("Collective"), "data", "elements.t
 const ELEMENTAL_SYMBOLS = lowercase.(strip.(ELEMENT_DATA[:,2]))
 const STATES_DATA = readdlm(joinpath(Pkg.dir("Collective"), "data", "states.tsv"), '\t', String, skipstart=1)
 const STATE_ABBREVIATIONS = strip.(lowercase.(STATES_DATA[:,2]))
+const WORDS = wordlist(open(joinpath(Pkg.dir("Collective"), "data", "113809of.fic")))
+
+const bitstallies = collect(Set(BitsTally.(WORDS)))
+
+function has_transaddition(t::BitsTally)
+    for other in bitstallies
+        if istransaddition(other, t)
+            return true
+        end
+    end
+    return false
+end
+
+function has_transdeletion(t::BitsTally)
+    for other in bitstallies
+        if istransaddition(t, other)
+            return true
+        end
+    end
+    return false
+end
 
 parenwrap(s) = "($s)"
 

--- a/src/features.jl
+++ b/src/features.jl
@@ -99,11 +99,11 @@ const STATES_DATA = readdlm(joinpath(Pkg.dir("Collective"), "data", "states.tsv"
 const STATE_ABBREVIATIONS = strip.(lowercase.(STATES_DATA[:,2]))
 const WORDS = wordlist(open(joinpath(Pkg.dir("Collective"), "data", "113809of.fic")))
 
-const bitstallies = collect(Set(BitsTally.(WORDS)))
+const bitstallies = Set(BitsTally.(WORDS))
 
 function has_transaddition(t::BitsTally)
-    for other in bitstallies
-        if istransaddition(other, t)
+    for letter in 'a':'z'
+        if (t + letter) in bitstallies
             return true
         end
     end
@@ -111,8 +111,8 @@ function has_transaddition(t::BitsTally)
 end
 
 function has_transdeletion(t::BitsTally)
-    for other in bitstallies
-        if istransaddition(t, other)
+    for letter in 'a':'z'
+        if (t - letter) in bitstallies
             return true
         end
     end

--- a/test/puzzles/rubik.jl
+++ b/test/puzzles/rubik.jl
@@ -1,5 +1,5 @@
 # http://web.mit.edu/puzzle/www/2013/coinheist.com/rubik/clockwork_orange/index.html
-@testset "rubik" begin
+@testset "rubik clockwork orange meta" begin
     f = best_feature(["armoredrecon", "hypapante", "commemorativebats", "derricktruck", "brownrot", "attorneysgeneral", "sacrosanct", "impromptu"])
     @test f.description == "has at least 2 letters repeated exactly 2 times each"
 end

--- a/test/puzzles/rubik.jl
+++ b/test/puzzles/rubik.jl
@@ -1,5 +1,5 @@
 # http://web.mit.edu/puzzle/www/2013/coinheist.com/rubik/clockwork_orange/index.html
 @testset "rubik clockwork orange meta" begin
-    f = best_feature(["armoredrecon", "hypapante", "commemorativebats", "derricktruck", "brownrot", "attorneysgeneral", "sacrosanct", "impromptu"])
+    f = best_feature(["armoredrecon", "hypapante", "commemorativebats", "derricktruck", "brownrot", "attorneysgeneral", "sacrosanct", "impromptu"], 1)
     @test f.description == "has at least 2 letters repeated exactly 2 times each"
 end


### PR DESCRIPTION
@zarvox I figured out a cute way to check for transadditions/deletions reasonably quickly. It's still slower than I'd like (computing all feature frequencies went from 7s to 50s), and probably allowing too many possible weird transadditions/deletions, but it's a start. 

Also, amusingly, this breaks the Rubik Clockwork Orange meta, since apparently all of those words also have a single-letter transdeletion. Maybe checking all of sowpods for the transdeletion/addition results is too broad? 